### PR TITLE
Fix: Auto-Login When AFK Logged

### DIFF
--- a/unethical-autologin/src/main/java/net/unethicalite/plugins/autologin/UnethicalAutoLoginPlugin.java
+++ b/unethical-autologin/src/main/java/net/unethicalite/plugins/autologin/UnethicalAutoLoginPlugin.java
@@ -67,6 +67,10 @@ public class UnethicalAutoLoginPlugin extends Plugin
 			case 4:
 				enterAuth();
 				break;
+			case 24:
+				prepareLogin();
+				client.getCallbacks().post(new LoginStateChanged(2));
+				break;
 		}
 	}
 

--- a/unethical-autologin/src/main/java/net/unethicalite/plugins/autologin/UnethicalAutoLoginPlugin.java
+++ b/unethical-autologin/src/main/java/net/unethicalite/plugins/autologin/UnethicalAutoLoginPlugin.java
@@ -63,7 +63,6 @@ public class UnethicalAutoLoginPlugin extends Plugin
 			case 2:
 				login();
 				break;
-
 			case 4:
 				enterAuth();
 				break;

--- a/unethical-autologin/unethical-autologin.gradle.kts
+++ b/unethical-autologin/unethical-autologin.gradle.kts
@@ -1,4 +1,4 @@
-version = "0.0.1"
+version = "0.0.2"
 
 project.extra["PluginName"] = "Unethical Auto Login"
 project.extra["PluginDescription"] = "Automatically logs in specified account in config"


### PR DESCRIPTION
This PR proposes changes that modify the unethicalite-autologin plugin in order to accommodate being 5-min and 6-hour logged. If the player is 5-min or 6-hour logged, the plugin will automatically set the login state back to the login screen and input the user's credentials.

Also bumped plugin version.

Please let me know if you find any areas for improvement.