### PR TITLE
Unethical Explorer: Add Stop Hotkey and Close Map on Selection

### DIFF
--- a/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerConfig.java
+++ b/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerConfig.java
@@ -17,7 +17,7 @@ public interface ExplorerConfig extends Config
 	)
 	default Keybind stopKeyBind()
 	{
-		return Keybind.SHIFT;
+		return Keybind.NOT_SET;
 	}
 
 	@ConfigItem(

--- a/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerConfig.java
+++ b/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerConfig.java
@@ -4,6 +4,7 @@ import net.runelite.client.config.Button;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Keybind;
 
 @ConfigGroup("unethicalexplorer")
 public interface ExplorerConfig extends Config
@@ -28,5 +29,16 @@ public interface ExplorerConfig extends Config
 	default Button walk()
 	{
 		return new Button();
+	}
+
+	@ConfigItem(
+		keyName = "keyBind",
+		name = "Stop explorer hotkey",
+		description = "Hotkey to stop the explorer",
+		position = 2
+	)
+	default Keybind stopKeyBind()
+	{
+		return Keybind.SHIFT;
 	}
 }

--- a/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerConfig.java
+++ b/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerConfig.java
@@ -10,10 +10,32 @@ import net.runelite.client.config.Keybind;
 public interface ExplorerConfig extends Config
 {
 	@ConfigItem(
+		keyName = "keyBind",
+		name = "Stop explorer hotkey",
+		description = "Hotkey to stop the explorer",
+		position = 0
+	)
+	default Keybind stopKeyBind()
+	{
+		return Keybind.SHIFT;
+	}
+
+	@ConfigItem(
+		keyName = "closeMap",
+		name = "Close map on selection",
+		description = "Close the world map after selecting a destination",
+		position = 1
+	)
+	default boolean closeMap()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 			keyName = "coords",
 			name = "Custom coords",
 			description = "Walk to the specified coordinates",
-			position = 0
+			position = 2
 	)
 	default String coords()
 	{
@@ -24,21 +46,10 @@ public interface ExplorerConfig extends Config
 			keyName = "walk",
 			name = "Walk to",
 			description = "Walk to set coordinates",
-			position = 1
+			position = 3
 	)
 	default Button walk()
 	{
 		return new Button();
-	}
-
-	@ConfigItem(
-		keyName = "keyBind",
-		name = "Stop explorer hotkey",
-		description = "Hotkey to stop the explorer",
-		position = 2
-	)
-	default Keybind stopKeyBind()
-	{
-		return Keybind.SHIFT;
 	}
 }

--- a/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerPlugin.java
+++ b/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerPlugin.java
@@ -12,6 +12,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ConfigButtonClicked;
 import net.runelite.api.events.MenuOpened;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -105,7 +106,10 @@ public class ExplorerPlugin extends LoopedPlugin
 			.setOption("<col=00ff00>Explorer:</col>")
 			.setTarget("Walk here")
 			.setType(MenuAction.RUNELITE)
-			.onClick(e -> setDestination(mouse));
+			.onClick(e -> {
+				setDestination(mouse);
+				closeWorldMap();
+			});
 	}
 
 	@Subscribe
@@ -132,6 +136,15 @@ public class ExplorerPlugin extends LoopedPlugin
 	{
 		destination = Walker.nearestWalkableTile(wp);
 		log.debug("Walking to {}", destination);
+	}
+
+	private void closeWorldMap()
+	{
+		Widget closeWorldMap = Widgets.get(WidgetID.WORLD_MAP_GROUP_ID, closeButton -> closeButton.hasAction("Close"));
+		if (closeWorldMap != null && closeWorldMap.isVisible())
+		{
+			closeWorldMap.interact("Close");
+		}
 	}
 
 	@Override

--- a/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerPlugin.java
+++ b/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerPlugin.java
@@ -108,7 +108,9 @@ public class ExplorerPlugin extends LoopedPlugin
 			.setType(MenuAction.RUNELITE)
 			.onClick(e -> {
 				setDestination(mouse);
-				closeWorldMap();
+
+				if (config.closeMap())
+					closeWorldMap();
 			});
 	}
 

--- a/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerPlugin.java
+++ b/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerPlugin.java
@@ -1,6 +1,10 @@
 package net.unethicalite.plugins.explorer;
 
 import com.google.inject.Provides;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
@@ -11,7 +15,9 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.util.HotkeyListener;
 import net.unethicalite.api.entities.Players;
 import net.unethicalite.api.game.Game;
 import net.unethicalite.api.movement.Movement;
@@ -20,16 +26,11 @@ import net.unethicalite.api.plugins.LoopedPlugin;
 import net.unethicalite.api.widgets.Widgets;
 import org.pf4j.Extension;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Objects;
-import java.util.regex.Pattern;
-
 @Extension
 @PluginDescriptor(
-		name = "Unethical Explorer",
-		description = "Right click anywhere within the World Map to walk there",
-		enabledByDefault = false
+	name = "Unethical Explorer",
+	description = "Right click anywhere within the World Map to walk there",
+	enabledByDefault = false
 )
 @Singleton
 @Slf4j
@@ -45,11 +46,35 @@ public class ExplorerPlugin extends LoopedPlugin
 
 	private WorldPoint destination;
 
+	@Inject
+	private KeyManager keyManager;
+
+	@Override
+	protected void startUp()
+	{
+		keyManager.registerKeyListener(hotkeyListener);
+	}
+
 	@Override
 	public void shutDown()
 	{
 		destination = null;
+		keyManager.unregisterKeyListener(hotkeyListener);
+
 	}
+
+	private final HotkeyListener hotkeyListener = new HotkeyListener(() -> config.stopKeyBind())
+	{
+		@Override
+		public void hotkeyPressed()
+		{
+			// If the hotkey is pressed and there is currently a destination, stop walking
+			if (destination != null)
+			{
+				destination = null;
+			}
+		}
+	};
 
 	@Subscribe
 	public void onMenuOpened(MenuOpened event)
@@ -57,10 +82,10 @@ public class ExplorerPlugin extends LoopedPlugin
 		if (destination != null)
 		{
 			client.createMenuEntry(1)
-					.setOption("<col=00ff00>Explorer:</col>")
-					.setTarget("Cancel walking")
-					.setType(MenuAction.RUNELITE)
-					.onClick(e -> destination = null);
+				.setOption("<col=00ff00>Explorer:</col>")
+				.setTarget("Cancel walking")
+				.setType(MenuAction.RUNELITE)
+				.onClick(e -> destination = null);
 			return;
 		}
 
@@ -77,10 +102,10 @@ public class ExplorerPlugin extends LoopedPlugin
 		}
 
 		client.createMenuEntry(1)
-				.setOption("<col=00ff00>Explorer:</col>")
-				.setTarget("Walk here")
-				.setType(MenuAction.RUNELITE)
-				.onClick(e -> setDestination(mouse));
+			.setOption("<col=00ff00>Explorer:</col>")
+			.setTarget("Walk here")
+			.setType(MenuAction.RUNELITE)
+			.onClick(e -> setDestination(mouse));
 	}
 
 	@Subscribe
@@ -99,7 +124,7 @@ public class ExplorerPlugin extends LoopedPlugin
 
 		String[] split = coords.split(" ");
 		setDestination(Walker.nearestWalkableTile(
-				new WorldPoint(Integer.parseInt(split[0]), Integer.parseInt(split[1]), Integer.parseInt(split[2]))
+			new WorldPoint(Integer.parseInt(split[0]), Integer.parseInt(split[1]), Integer.parseInt(split[2]))
 		));
 	}
 
@@ -123,8 +148,8 @@ public class ExplorerPlugin extends LoopedPlugin
 		}
 
 		if (destination == null
-				|| destination.distanceTo(Players.getLocal().getWorldLocation()) <= 2
-				|| Objects.equals(Movement.getDestination(), destination)
+			|| destination.distanceTo(Players.getLocal().getWorldLocation()) <= 2
+			|| Objects.equals(Movement.getDestination(), destination)
 		)
 		{
 			destination = null;

--- a/unethical-explorer/unethical-explorer.gradle.kts
+++ b/unethical-explorer/unethical-explorer.gradle.kts
@@ -1,4 +1,4 @@
-version = "0.0.2"
+version = "0.0.3"
 
 project.extra["PluginName"] = "Unethical Explorer"
 project.extra["PluginDescription"] = "Automatically walks places"


### PR DESCRIPTION
This PR adds the following functionality to the Unethical Explorer plugin:
* The option to set a hotkey to stop the Unethical Explorer plugin
  * By default no hotkey is set
* The option to close the world map after selecting a destination
  * By default the map will close after selecting a destination

This should resolve https://github.com/unethicalite/unethicalite/issues/167 and also add a feature that was requested in the discord.

Please let me know if you find any areas for improvements.