### PR TITLE
Change how hotkey works in Unethical Explorer

### DIFF
--- a/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerConfig.java
+++ b/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerConfig.java
@@ -53,12 +53,12 @@ public interface ExplorerConfig extends Config
 
 
 	@ConfigItem(
-		keyName = "keyBind",
-		name = "Stop explorer hotkey",
-		description = "Hotkey to stop the explorer",
+		keyName = "toggleKeyBind",
+		name = "Start/Stop hotkey",
+		description = "Hotkey to start/stop the explorer",
 		position = 24
 	)
-	default Keybind stopKeyBind()
+	default Keybind toggleKeyBind()
 	{
 		return Keybind.NOT_SET;
 	}

--- a/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerPlugin.java
+++ b/unethical-explorer/src/main/java/net/unethicalite/plugins/explorer/ExplorerPlugin.java
@@ -74,7 +74,7 @@ public class ExplorerPlugin extends LoopedPlugin
 
 	}
 
-	private final HotkeyListener hotkeyListener = new HotkeyListener(() -> config.stopKeyBind())
+	private final HotkeyListener hotkeyListener = new HotkeyListener(() -> config.toggleKeyBind())
 	{
 		@Override
 		public void hotkeyPressed()
@@ -83,6 +83,48 @@ public class ExplorerPlugin extends LoopedPlugin
 			if (destination != null)
 			{
 				destination = null;
+			}
+			else
+			{
+				WorldPoint location = null;
+
+				switch (config.category())
+				{
+					case QUEST:
+						WorldPoint questLocation = getWorldPointLocation("Quest Helper");
+						if (questLocation != null)
+						{
+							location = questLocation;
+						}
+						break;
+					case CLUE:
+						WorldPoint clueLocation = getWorldPointLocation("Clue Scroll");
+						if (clueLocation != null)
+						{
+							location = clueLocation;
+						}
+						break;
+					case BANKS:
+						location = config.bankLocation().getArea().getCenter();
+						break;
+					case CUSTOM:
+						String coords = config.coords();
+						if (!WORLD_POINT_PATTERN.matcher(coords).matches())
+						{
+							return;
+						}
+						String[] split = coords.split(" ");
+						location = new WorldPoint(Integer.parseInt(split[0]), Integer.parseInt(split[1]), Integer.parseInt(split[2]));
+						break;
+				}
+				if (location != null)
+				{
+					setDestination(Walker.nearestWalkableTile(location));
+				}
+				else
+				{
+					MessageUtils.addMessage("Invalid Selection");
+				}
 			}
 		}
 	};


### PR DESCRIPTION
Change hotkey so it stops when pressed and there is a destination, and it starts when there is no destination (checks for quest, bank, clue or custom). This makes it so you don't have to keep settings open to press the "Walk to" button when using the hotkey often, especially while questing.